### PR TITLE
Use environment variable to access installation directory

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -72,11 +72,11 @@ ${BOARD_BUILDDIR}/${TOP}.bit: ${BOARD_BUILDDIR}/${TOP}.fasm
 
 download: ${BOARD_BUILDDIR}/${TOP}.bit
 	if [ $(TARGET)='arty_35' ]; then \
-	  openocd -f ~/opt/symbiflow/xc7/conda/envs/xc7/share/openocd/scripts/board/digilent_arty.cfg -c "init; pld load 0 ${BOARD_BUILDDIR}/${TOP}.bit; exit"; \
+	  openocd -f ${INSTALL_DIR}/xc7/conda/envs/xc7/share/openocd/scripts/board/digilent_arty.cfg -c "init; pld load 0 ${BOARD_BUILDDIR}/${TOP}.bit; exit"; \
 	elif [ $(TARGET)='arty_100' ]; then \
-	  openocd -f ~/opt/symbiflow/xc7/conda/envs/xc7/share/openocd/scripts/board/digilent_arty.cfg -c "init; pld load 0 ${BOARD_BUILDDIR}/${TOP}.bit; exit"; \
+	  openocd -f ${INSTALL_DIR}/xc7/conda/envs/xc7/share/openocd/scripts/board/digilent_arty.cfg -c "init; pld load 0 ${BOARD_BUILDDIR}/${TOP}.bit; exit"; \
 	elif [ $(TARGET)='basys3' ]; then \
-	  openocd -f ~/opt/symbiflow/xc7/conda/envs/xc7/share/openocd/scripts/board/digilent_arty.cfg -c "init; pld load 0 ${BOARD_BUILDDIR}/${TOP}.bit; exit"; \
+	  openocd -f ${INSTALL_DIR}/xc7/conda/envs/xc7/share/openocd/scripts/board/digilent_arty.cfg -c "init; pld load 0 ${BOARD_BUILDDIR}/${TOP}.bit; exit"; \
 	else  \
 	  echo "The commands needed to download the bitstreams to the board type specified are not currently supported by the symbiflow makefiles. \
     Please see documentation for more information."; \


### PR DESCRIPTION
The `INSTALL_DIR` environment variable was not used in the portion of the Makefile responsible for downloading to an FPGA. If a path different from the recommended installation path was used, the download make target did not work.

I have replaced the relevant parts with the environment variable.