### PR TITLE
Remove CentOS 8 from CI

### DIFF
--- a/.github/scripts/generate_job_matrix.py
+++ b/.github/scripts/generate_job_matrix.py
@@ -51,7 +51,6 @@ jobs = []
 
 osvers = [
     ("ubuntu", "focal"),
-    ("centos", "8"),
     ("debian", "buster"),
     ("debian", "bullseye"),
     ("debian", "sid"),

--- a/.github/workflows/sphinx-tuttest.yml
+++ b/.github/workflows/sphinx-tuttest.yml
@@ -46,12 +46,6 @@ jobs:
         run: apt -qqy update && apt -qqy install git wget locales && locale-gen $LANG
 
       - name: Install utils
-        if: ${{matrix.os == 'centos' && matrix.os-version == '8'}}
-        run: |
-          sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-          sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-
-      - name: Install utils
         if: ${{matrix.os == 'centos'}}
         run: yum -y install git wget
 


### PR DESCRIPTION
CentOS 8 reached **EOL** in December 2021. As such it's no longer maintained and things start to break. Some package mirros fail to respond on-time or their transfer rate are too slow and are causing timeouts when installing packages, which causes the CI to occasionally fail on CentOS 8 images. [It also looks like packages are slowly being removed from the official CentOS 8 repos](https://www.centos.org/news-and-events/convert-to-stream-8/).

I believe it's time to deprecate support for this OS.