### PR TITLE
Modify board paths in common.mk to follow rename

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -72,11 +72,11 @@ ${BOARD_BUILDDIR}/${TOP}.bit: ${BOARD_BUILDDIR}/${TOP}.fasm
 
 download: ${BOARD_BUILDDIR}/${TOP}.bit
 	if [ $(TARGET)='arty_35' ]; then \
-	  openocd -f ~/opt/symbiflow/xc7/conda/envs/xc7/share/openocd/scripts/board/digilent_arty.cfg -c "init; pld load 0 ${BOARD_BUILDDIR}/${TOP}.bit; exit"; \
+	  openocd -f ~/opt/f4pga/xc7/conda/envs/xc7/share/openocd/scripts/board/digilent_arty.cfg -c "init; pld load 0 ${BOARD_BUILDDIR}/${TOP}.bit; exit"; \
 	elif [ $(TARGET)='arty_100' ]; then \
-	  openocd -f ~/opt/symbiflow/xc7/conda/envs/xc7/share/openocd/scripts/board/digilent_arty.cfg -c "init; pld load 0 ${BOARD_BUILDDIR}/${TOP}.bit; exit"; \
+	  openocd -f ~/opt/f4pga/xc7/conda/envs/xc7/share/openocd/scripts/board/digilent_arty.cfg -c "init; pld load 0 ${BOARD_BUILDDIR}/${TOP}.bit; exit"; \
 	elif [ $(TARGET)='basys3' ]; then \
-	  openocd -f ~/opt/symbiflow/xc7/conda/envs/xc7/share/openocd/scripts/board/digilent_arty.cfg -c "init; pld load 0 ${BOARD_BUILDDIR}/${TOP}.bit; exit"; \
+	  openocd -f ~/opt/f4pga/xc7/conda/envs/xc7/share/openocd/scripts/board/digilent_arty.cfg -c "init; pld load 0 ${BOARD_BUILDDIR}/${TOP}.bit; exit"; \
 	else  \
 	  echo "The commands needed to download the bitstreams to the board type specified are not currently supported by the F4PGA makefiles. \
     Please see documentation for more information."; \


### PR DESCRIPTION
I was following through the docs and noticed this was looking for files
in ~/opt/symbiflow

I could see changing this to use a variable, maybe, but I don't have any good
ideas for improving this to not assume the install is at ~/opt/f4pga.