### PR TITLE
Fix comma in counter module instance

### DIFF
--- a/xc7/counter_test/counter_zynq.v
+++ b/xc7/counter_test/counter_zynq.v
@@ -30,7 +30,7 @@ module top (
   PS7 PS7 (
       .EMIOGPIOO (emio_gpio_o),
       .EMIOGPIOTN(emio_gpio_t),
-      .EMIOGPIOI (emio_gpio_i),
+      .EMIOGPIOI (emio_gpio_i)
   );
 
 


### PR DESCRIPTION
Trailing commas are not supported in port lists for module instances as per section 23.3.2 of the standard.