### PR TITLE
EOS-S3 update

### DIFF
--- a/docs/building-examples.rst
+++ b/docs/building-examples.rst
@@ -47,6 +47,8 @@ Next, prepare the environment:
          :name: conda-prep-env-eos-s3
 
          export PATH="$F4PGA_INSTALL_DIR/$FPGA_FAM/quicklogic-arch-defs/bin:$PATH";
+         export F4PGA_ENV_BIN="$F4PGA_INSTALL_DIR/$FPGA_FAM/quicklogic-arch-defs/bin";
+         export F4PGA_ENV_SHARE="$F4PGA_INSTALL_DIR/$FPGA_FAM/quicklogic-arch-defs/share/symbiflow";
          source "$F4PGA_INSTALL_DIR/$FPGA_FAM/conda/etc/profile.d/conda.sh"
 
 Finally, enter your working Conda environment:

--- a/docs/getting.rst
+++ b/docs/getting.rst
@@ -143,7 +143,7 @@ Download architecture definitions:
       .. code-block:: bash
          :name: download-arch-def-eos-s3
 
-         wget -qO- https://storage.googleapis.com/symbiflow-arch-defs-install/quicklogic-arch-defs-d6d05185.tar.gz | tar -xzC $F4PGA_INSTALL_DIR/$FPGA_FAM/
+         wget -qO- https://storage.googleapis.com/symbiflow-arch-defs-install/quicklogic-arch-defs-qlf-fc5d8da.tar.gz | tar -xzC $F4PGA_INSTALL_DIR/$FPGA_FAM/
 
 If the above commands exited without errors, you have successfully installed and configured your working environment.
 

--- a/eos-s3/btn_counter/Makefile
+++ b/eos-s3/btn_counter/Makefile
@@ -3,7 +3,7 @@ current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
 TOP:=top
 VERILOG:=btn_counter.v
 DEVICE := ql-eos-s3
-PARTNAME := pd64
+PARTNAME := PD64
 PCF:=chandalar.pcf
 
 all:

--- a/eos-s3/btn_counter/README.rst
+++ b/eos-s3/btn_counter/README.rst
@@ -7,4 +7,6 @@ counter example, run the following command:
 .. code-block:: bash
    :name: eos-s3-counter
 
+   #FIXME: make sure FPGA_FAM is available and remove env var export
+   export FPGA_FAM=eos-s3
    make -C btn_counter

--- a/eos-s3/btn_counter/chandalar.pcf
+++ b/eos-s3/btn_counter/chandalar.pcf
@@ -1,5 +1,5 @@
 set_io clk      A3
-set_io led(0)   H7
-set_io led(1)   G7
-set_io led(2)   F6
-set_io led(3)   E8
+set_io led[0]   H7
+set_io led[1]   G7
+set_io led[2]   F6
+set_io led[3]   E8

--- a/eos-s3/environment.yml
+++ b/eos-s3/environment.yml
@@ -3,9 +3,9 @@ channels:
   - conda-forge
   - litex-hub
 dependencies:
-  - litex-hub::quicklogic-yosys=0.8.0_105_gd282be04=20210625_074838
-  - litex-hub::quicklogic-yosys-plugins=1.2.0_11_g21045a9=20210625_074838
-  - litex-hub::vtr-optimized=8.0.0_4023_ge73e88940=20210625_074838
+  - litex-hub::yosys=0.15_51_g6318db615=20220317_162926_py37
+  - litex-hub::symbiflow-yosys-plugins=1.0.0_7_832_ga2a80a1=20220317_162926
+  - litex-hub::vtr-optimized=8.0.0_5338_g829c06d8f=20220409_131122
   - make
   - lxml
   - simplejson

--- a/eos-s3/requirements.txt
+++ b/eos-s3/requirements.txt
@@ -1,3 +1,4 @@
 python-constraint
 serial
 git+https://github.com/QuickLogic-Corp/quicklogic-fasm@aaf4c314a165b6185b0983019d8aae4d0d4db6cb
+https://github.com/chipsalliance/f4pga/archive/main.zip#subdirectory=f4pga

--- a/eos-s3/requirements.txt
+++ b/eos-s3/requirements.txt
@@ -1,3 +1,3 @@
 python-constraint
 serial
-git+https://github.com/QuickLogic-Corp/quicklogic-fasm@57b6e60574a9d483dc94710d0d3ff42a62b4ec41
+git+https://github.com/QuickLogic-Corp/quicklogic-fasm@aaf4c314a165b6185b0983019d8aae4d0d4db6cb


### PR DESCRIPTION
This PR is required in ongoing EOS-S3 upstreaming effort. It bumps yosys, yosys plugins, quicklogic-fasm and vtr packages. It also changes the part name in Makefile to uppercase and changes the ports in PCF file from single bit ones to multi bit because bumped VPR is now able to emit post-implementation netlist with merged multi bit ports.