### PR TITLE
Add documentation on updating the plugin manually

### DIFF
--- a/xc7/nightly.rst
+++ b/xc7/nightly.rst
@@ -1,0 +1,29 @@
+Obtaining nightly version of the tools
+======================================
+
+Sometimes it may be preferable to get the latest versions of the tools even beforethe full Toolchain is validated and upgraded. These tools **are not guaranteered to be bug free**, but they enable users to take advantage of the latest fixes available.
+
+Updating Yosys SystemVerilog plugin
+-----------------------------------
+
+Activate the conda repository for the correct family:
+
+.. code-block:: bash
+   :name: activate-xc7
+
+   conda activate xc7
+
+Obtain the latest release of the plugin from `here <https://github.com/antmicro/yosys-uhdm-plugin-integration/releases>`_:
+
+.. code-block:: bash
+   :name: get-plugin
+
+   wget https://github.com/antmicro/yosys-uhdm-plugin-integration/releases/download/e3a87e3-2022-06-17/yosys-uhdm-plugin-e3a87e3-Ubuntu-20.04-focal-x86_64.tar.gz
+   tar -xzf yosys-uhdm-plugin-e3a87e3-Ubuntu-20.04-focal-x86_64.tar.gz
+
+Install the plugin using provided installation script. It will use the `yosys-config` from conda, so it will install into the conda environment.
+
+.. code-block:: bash
+   :name: install-plugin
+
+   ./install-plugin.sh

--- a/xc7/nightly.rst
+++ b/xc7/nightly.rst
@@ -6,6 +6,9 @@ Sometimes it may be preferable to get the latest versions of the tools even befo
 Updating Yosys SystemVerilog plugin
 -----------------------------------
 
+**Warning**: the expected usage of the plugin by using the :code:`read_systemverilog` command (used by default in F4PGA flow) should work. When using the plugin by calling :code:`read_uhdm` command, take additional care to use the same Surelog and UHDM version for creating and reading the UHDM file - updating only the plugin can create a mismatch in this case.
+
+
 Make sure :code:`curl`, :code:`jq`, :code:`tar` and :code:`wget` are installed (used to automatically download newest version):
 
 .. code-block:: bash

--- a/xc7/nightly.rst
+++ b/xc7/nightly.rst
@@ -1,10 +1,17 @@
 Obtaining nightly version of the tools
 ======================================
 
-Sometimes it may be preferable to get the latest versions of the tools even beforethe full Toolchain is validated and upgraded. These tools **are not guaranteered to be bug free**, but they enable users to take advantage of the latest fixes available.
+Sometimes it may be preferable to get the latest versions of the tools even before the full Toolchain is validated and upgraded. These tools **are not guaranteered to be bug free**, but they enable users to take advantage of the latest fixes available.
 
 Updating Yosys SystemVerilog plugin
 -----------------------------------
+
+Make sure :code:`curl`, :code:`jq`, :code:`tar` and :code:`wget` are installed (used to automatically download newest version):
+
+.. code-block:: bash
+   :name: activate-xc7
+
+   apt install curl jq tar wget
 
 Activate the conda repository for the correct family:
 
@@ -18,8 +25,7 @@ Obtain the latest release of the plugin from `here <https://github.com/antmicro/
 .. code-block:: bash
    :name: get-plugin
 
-   wget https://github.com/antmicro/yosys-uhdm-plugin-integration/releases/download/e3a87e3-2022-06-17/yosys-uhdm-plugin-e3a87e3-Ubuntu-20.04-focal-x86_64.tar.gz
-   tar -xzf yosys-uhdm-plugin-e3a87e3-Ubuntu-20.04-focal-x86_64.tar.gz
+   curl https://api.github.com/repos/antmicro/yosys-uhdm-plugin-integration/releases/latest | jq .assets[1] | grep "browser_download_url" | grep -Eo 'https://[^\"]*' | xargs wget -O - | tar -xz
 
 Install the plugin using provided installation script. It will use the `yosys-config` from conda, so it will install into the conda environment.
 


### PR DESCRIPTION
This PR adds instructions on how to update systemverilog-plugin manually using the release from [plugin integration repository](https://github.com/antmicro/yosys-uhdm-plugin-integration/releases). It should then be available inside the f4pga flow.