### PR TITLE
docs/requirements: temporarily pin sphinx to v4.5.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==4.5.0
 docutils
 git+https://github.com/f4pga/sphinx_f4pga_theme.git@f4pga#egg=sphinx-f4pga-theme
 sphinx-tabs


### PR DESCRIPTION
It seems that extension `sphinx_jinja` is not compatible with Sphinx v5 yet. See https://github.com/tardyp/sphinx-jinja/issues/35.
This PR pins sphinx to v4.5.0 in order to avoid broken builds on RTD: https://readthedocs.org/projects/f4pga-examples/builds/.