### PR TITLE
xc7: dependency updates

### DIFF
--- a/docs/getting.rst
+++ b/docs/getting.rst
@@ -131,8 +131,8 @@ Download architecture definitions:
 
          mkdir -p $F4PGA_INSTALL_DIR/xc7/install
 
-         F4PGA_TIMESTAMP='20220523-230829'
-         F4PGA_HASH='934b12d'
+         F4PGA_TIMESTAMP='20220714-173445'
+         F4PGA_HASH='f7afc12'
 
          for PKG in install xc7a50t_test xc7a100t_test xc7a200t_test xc7z010_test; do
            wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/${F4PGA_TIMESTAMP}/symbiflow-arch-defs-${PKG}-${F4PGA_HASH}.tar.xz | tar -xJC $F4PGA_INSTALL_DIR/${FPGA_FAM}/install

--- a/xc7/environment.yml
+++ b/xc7/environment.yml
@@ -3,12 +3,12 @@ channels:
   - litex-hub
 dependencies:
   - litex-hub::openfpgaloader==0.8.0_114_g057ce93=20220706_155948
-  - litex-hub::prjxray-tools=0.1_2986_g5937733d=20220512_085338
-  - litex-hub::gcc-riscv64-elf-newlib=9.2.0=20201119_154229
-  - litex-hub::prjxray-db=0.0_257_g0a0adde=20220512_085338
-  - litex-hub::vtr-optimized=8.0.0_5383_gc012f19d3=20220512_085338
-  - litex-hub::yosys=0.17_7_g990c9b8e1=20220512_085338_py37
-  - litex-hub::symbiflow-yosys-plugins=1.0.0_7_919_g2fa356d=20220512_085338
+  - litex-hub::prjxray-tools=0.1_3015_gae546d6b=20220708_203356
+  - litex-hub::gcc-riscv64-elf-newlib=10.1.0=20220706_160221
+  - litex-hub::prjxray-db=0.0_257_g0a0adde=20220708_203356
+  - litex-hub::vtr-optimized=8.0.0_5699_g25e723a24=20220708_203356
+  - litex-hub::yosys=0.19_21_ga82eff2e2=20220720_081021_py37
+  - litex-hub::symbiflow-yosys-plugins=1.0.0_7_1027_g52cdcc4=20220720_081021
   - make
   - lxml
   - simplejson

--- a/xc7/requirements.txt
+++ b/xc7/requirements.txt
@@ -16,5 +16,5 @@ yapf==0.24.0
 python-constraint
 https://github.com/chipsalliance/f4pga/archive/main.zip#subdirectory=f4pga
 fasm
-git+https://github.com/SymbiFlow/prjxray.git@e25c20a8f158cc5e94eb62e3b74e16fc9d6c1d26#egg=prjxray
-git+https://github.com/symbiflow/xc-fasm.git@14afc2bae24cbf6ee5e7d057a58b4cbd776358d0#egg=xc-fasm
+git+https://github.com/f4pga/prjxray.git@ae546d6b7648bf4df9cf63f0b25b2028b5623c43#egg=prjxray
+git+https://github.com/chipsalliance/f4pga-xc-fasm.git@25dc605c9c0896204f0c3425b52a332034cf5e5c#egg=xc-fasm


### PR DESCRIPTION
This PR updates locked dependencies in the xc7 conda environment to the latest versions (as of July 18th).