### PR TITLE
eos-s3: btn_counter: use F4PGA build flow by default

### DIFF
--- a/eos-s3/btn_counter/Makefile
+++ b/eos-s3/btn_counter/Makefile
@@ -6,5 +6,10 @@ DEVICE := ql-eos-s3
 PARTNAME := PD64
 PCF:=chandalar.pcf
 
+ifdef F4PGA_USE_DEPRECATED
 all:
 	ql_symbiflow -compile -d ${DEVICE} -P ${PARTNAME} -v ${VERILOG} -t ${TOP} -p ${PCF}
+else
+all:
+	f4pga -vvv build --flow ./flow.json
+endif

--- a/eos-s3/btn_counter/flow.json
+++ b/eos-s3/btn_counter/flow.json
@@ -1,0 +1,26 @@
+{
+    "default_part": "EOS3FF512-PDN64",
+    "values": {
+        "top": "top"
+    },
+    "dependencies": {
+        "sources": [
+            "./btn_counter.v"
+        ],
+        "synth_log": "synth.log",
+        "pack_log": "pack.log",
+        "analysis_log": "analysis.log"
+    },
+    "EOS3FF512-PDN64": {
+        "default_target": "bitstream",
+        "dependencies": {
+            "build_dir": "build",
+            "pcf": "./chandalar.pcf",
+            "sdc-in": "./dummy.sdc"
+        },
+        "values": {
+            "part": "ql-eos-s3",
+            "package": "PD64"
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>